### PR TITLE
Update documentation for current Redis layout

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,10 +2,9 @@
 
 ## Project Structure & Module Organization
 - `Dockerfile` builds the Redis server image from source on Alpine.
-- `Dockerfile.arm64` builds a lightweight ARM64 redis-cli image.
 - `docker-entrypoint.sh` mirrors upstream entrypoint logic for permissions and module loading.
 - `redis.conf` contains a sample configuration.
-- `redis-stack.yml` is a local stack example for deployments.
+- `../docker-swarm/stacks/redis-stack.yml` is the local swarm stack example for deployments.
 
 ## Build, Test, and Development Commands
 - `docker image build --no-cache -t kernel528/redis:8.6-rc1 -f Dockerfile .` builds the server image locally.

--- a/README.md
+++ b/README.md
@@ -11,14 +11,13 @@ Maintainer: kernel528
 This repository builds a Redis image based on the upstream `redis/docker-library-redis` Alpine Dockerfile, but uses the custom base image `kernel528/alpine:3.23.3` and tracks Redis `8.6-rc1`.
 
 Upstream reference:
-- https://github.com/redis/docker-library-redis/tree/release/8.4/alpine
+- https://github.com/redis/docker-library-redis
 
 ## Project Structure
 - `Dockerfile`: Redis server image build (Alpine).
-- `Dockerfile.arm64`: ARM64 helper image (redis-cli focused).
 - `docker-entrypoint.sh`: Upstream entrypoint logic with module loading and permission fixes.
 - `redis.conf`: Sample configuration file.
-- `redis-stack.yml`: Local stack deployment template.
+- `../docker-swarm/stacks/redis-stack.yml`: Local swarm stack deployment template.
 
 ## Build
 ```bash


### PR DESCRIPTION
## Summary

- Remove stale references to the deleted `Dockerfile.arm64` file.
- Point the Redis stack documentation to the active swarm stack in `docker-swarm`.
- Generalize the upstream Redis Dockerfile reference so it no longer points at the older 8.4 path.

## Validation

- Ran `git diff --check` for the documentation changes.