### PR TITLE
Update Redis to 8.6.4 on kernel528/alpine:3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,17 +1,17 @@
 kind: pipeline
 type: docker
-name: version-8.6-rc1
+name: version-8.6.4
 
 trigger:
   branch:
-    - '8.6-rc1'
+    - '8.6.4'
   event:
     - push
     - pull_request
 
 # Validate version branch builds without publishing
 steps:
-  - name: v8.6-rc1-docker-image-build
+  - name: v8.6.4-docker-image-build
     image: plugins/docker
     environment:
       DOCKER_BUILDKIT: 1
@@ -20,7 +20,7 @@ steps:
         - linux/amd64
       repo: kernel528/redis
       tags:
-        - '8.6-rc1-branch-${DRONE_BUILD_NUMBER}-amd64'
+        - '8.6.4-branch-${DRONE_BUILD_NUMBER}-amd64'
       dry_run: true
 ---
 
@@ -49,7 +49,7 @@ steps:
         - linux/amd64
       repo: kernel528/redis
       tags:
-        - '8.6-rc1-pr-${DRONE_PULL_REQUEST}-amd64'
+        - '8.6.4-pr-${DRONE_PULL_REQUEST}-amd64'
       dry_run: true
 
   - name: v8-docker-image-build-release
@@ -69,12 +69,12 @@ steps:
       repo: kernel528/redis
       tags:
         - '8'
-        - '8.6-rc1'
-        - '8.6-rc1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '8.6.4'
+        - '8.6.4-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Test docker image
   - name: v8-docker-test
-    image: kernel528/redis:8.6-rc1
+    image: kernel528/redis:8.6.4
     when:
       branch:
         - '8'

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.23.3
+FROM kernel528/alpine:3.24.1
 MAINTAINER Joe Sanders - inspired by https://github.com/goodsmileduck/redis-cli/Dockerfile
 
 # Set User to be root
@@ -18,8 +18,8 @@ RUN set -eux; \
 # we need setpriv package as busybox provides very limited functionality
 		setpriv \
 	;
-ARG REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.6-rc1.tar.gz
-ARG REDIS_DOWNLOAD_SHA=dc387a093cb4f956953492eeb613e833b53ee23a45625bde01cc6d2497a5c0e7
+ARG REDIS_DOWNLOAD_URL=https://github.com/redis/redis/archive/refs/tags/8.6.4.tar.gz
+ARG REDIS_DOWNLOAD_SHA=a2029c96311ab1ec2ae489076ae900b6497b3beaa7dc379de26b5df48f696f6c
 RUN set -eux; \
 	\
 	apk add --no-cache --virtual .build-deps \

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Maintainer: kernel528
 
 ## Overview
-This repository builds a Redis image based on the upstream `redis/docker-library-redis` Alpine Dockerfile, but uses the custom base image `kernel528/alpine:3.23.3` and tracks Redis `8.6-rc1`.
+This repository builds a Redis image based on the upstream `redis/docker-library-redis` Alpine Dockerfile, but uses the custom base image `kernel528/alpine:3.24.1` and tracks Redis `8.6.4`.
 
 Upstream reference:
 - https://github.com/redis/docker-library-redis
@@ -21,29 +21,29 @@ Upstream reference:
 
 ## Build
 ```bash
-docker image build --no-cache -t kernel528/redis:8.6-rc1 -f Dockerfile .
+docker image build --no-cache -t kernel528/redis:8.6.4 -f Dockerfile .
 ```
 
 ## Run
 Standalone server:
 ```bash
-docker container run -d --name redis -p 6379:6379 kernel528/redis:8.6-rc1
+docker container run -d --name redis -p 6379:6379 kernel528/redis:8.6.4
 ```
 
 CLI only:
 ```bash
-docker container run -it --rm kernel528/redis:8.6-rc1 redis-cli --version
+docker container run -it --rm kernel528/redis:8.6.4 redis-cli --version
 ```
 
 ## Refresh Workflow
 1) Update `Dockerfile` base image and Redis source URL/SHA to match the desired upstream release.
-2) Update `.drone.yml` tags for the new Redis version (for example `8.6-rc1` and `8.6-rc1-drone-build-<build>-amd64`).
+2) Update `.drone.yml` tags for the new Redis version (for example `8.6.4` and `8.6.4-drone-build-<build>-amd64`).
 3) Build and test locally.
 4) Merge into the `8` branch to publish versioned images.
 5) Merge into `main` to refresh the `latest` tag, then create a Git tag for the release.
 
 ## CI Tagging (Drone)
-- `8.6-rc1` branch: validation build only (no publish).
-- `8` branch push: publishes versioned tags like `8` and `8.6-rc1`.
+- `8.6.4` branch: validation build only (no publish).
+- `8` branch push: publishes versioned tags like `8` and `8.6.4`.
 - `main` branch push: publishes `latest`.
 - Git tags: publish `${DRONE_TAG}`.


### PR DESCRIPTION
## Changes

- **Redis**: `8.6-rc1` → `8.6.4` (stable release with security fixes and critical bug fixes)
- **Base image**: `kernel528/alpine:3.23.3` → `kernel528/alpine:3.24.1`
- Updated `REDIS_DOWNLOAD_URL` and `REDIS_DOWNLOAD_SHA` for 8.6.4
- Updated `.drone.yml` and `README.md` with new version tags

## Validation

- [x] Image built successfully with all modules (RedisJSON, RediSearch, RedisBloom, RedisTimeSeries)
- [x] `redis-cli --version` → `redis-cli 8.6.4`
- [x] `redis-server --version` → `Redis server v=8.6.4`
- SHA256 checksum verified for 8.6.4 source archive