### PR TITLE
Rebase Redis 8.6.4 on Alpine 3.24.1_1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -21,8 +21,10 @@ steps:
       tags:
         - '8'
         - '8.6.4'
+        - '8.6.4-3.24.1_1'
         - '8-drone-build-${DRONE_BUILD_NUMBER}'
         - '8.6.4-drone-build-${DRONE_BUILD_NUMBER}'
+        - '8.6.4-3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}'
 
   # Slack notification
   - name: slack-notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 MAINTAINER Joe Sanders - inspired by https://github.com/goodsmileduck/redis-cli/Dockerfile
 
 # Set User to be root

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Maintainer: kernel528
 
 ## Overview
-This repository builds a Redis image based on the upstream `redis/docker-library-redis` Alpine Dockerfile, but uses the custom base image `kernel528/alpine:3.24.1` and tracks Redis `8.6.4`.
+This repository builds a Redis image based on the upstream `redis/docker-library-redis` Alpine Dockerfile, but uses the custom base image `kernel528/alpine:3.24.1_1` and tracks Redis `8.6.4`.
 
 Upstream reference:
 - https://github.com/redis/docker-library-redis
@@ -21,29 +21,29 @@ Upstream reference:
 
 ## Build
 ```bash
-docker image build --no-cache -t kernel528/redis:8.6.4 -f Dockerfile .
+docker image build --no-cache -t kernel528/redis:8.6.4-3.24.1_1 -f Dockerfile .
 ```
 
 ## Run
 Standalone server:
 ```bash
-docker container run -d --name redis -p 6379:6379 kernel528/redis:8.6.4
+docker container run -d --name redis -p 6379:6379 kernel528/redis:8.6.4-3.24.1_1
 ```
 
 CLI only:
 ```bash
-docker container run -it --rm kernel528/redis:8.6.4 redis-cli --version
+docker container run -it --rm kernel528/redis:8.6.4-3.24.1_1 redis-cli --version
 ```
 
 ## Refresh Workflow
 1) Update `Dockerfile` base image and Redis source URL/SHA to match the desired upstream release.
-2) Update `.drone.yml` tags for the new Redis version (for example `8.6.4` and `8.6.4-drone-build-<build>-amd64`).
+2) Update `.drone.yml` tags for the Redis and base-image versions.
 3) Build and test locally.
 4) Merge into the `8` branch to publish versioned images.
 5) Merge into `main` to refresh the `latest` tag, then create a Git tag for the release.
 
 ## CI Tagging (Drone)
 - `8.6.4` branch: validation build only (no publish).
-- `8` branch push: publishes versioned tags like `8` and `8.6.4`.
+- `8` branch PRs publish versioned tags such as `8`, `8.6.4`, and `8.6.4-3.24.1_1`.
 - `main` branch push: publishes `latest`.
 - Git tags: publish `${DRONE_TAG}`.


### PR DESCRIPTION
## Summary
- rebase Redis 8.6.4 on kernel528/alpine:3.24.1_1
- retain compatibility tags and add a base-qualified immutable tag
- update Drone outputs and operator documentation

## Validation status
Blocked on native Linux Mint validation. Source retrieval and dependency setup progressed on macOS arm64, but QEMU terminated GCC during linux/amd64 compilation; the emulated build later exceeded 20 minutes.

Required on Linux Mint before marking ready:

```bash
docker image build --no-cache --platform linux/amd64 -t kernel528/redis:8.6.4-3.24.1_1 -f Dockerfile .
docker container run --rm kernel528/redis:8.6.4-3.24.1_1 redis-server --version
docker container run --rm kernel528/redis:8.6.4-3.24.1_1 redis-cli --version
```

Also start Redis and verify PING, SET, and GET. Do not merge until native validation passes.