### PR TITLE
Document image and Swarm release handoff

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,15 @@ docker container run -it --rm kernel528/redis:8.6.4-3.24.1_1 redis-cli --version
 1) Update `Dockerfile` base image and Redis source URL/SHA to match the desired upstream release.
 2) Update `.drone.yml` tags for the Redis and base-image versions.
 3) Build and test locally.
-4) Merge into the `8` branch to publish versioned images.
-5) Merge into `main` to refresh the `latest` tag, then create a Git tag for the release.
+4) Open a PR targeting `8`. The current PR pipeline publishes configured version and build tags, but these are pre-release artifacts and must not be used by downstream images or Swarm.
+5) Merge the validated changes through `main`, then create a Git tag from `main`; the tag pipeline publishes `${DRONE_TAG}` and refreshes `latest`.
+
+## Repository Relationships
+
+This independent repository is coordinated by [`docker-workspace`](https://github.com/kernel528/docker-workspace), consumes [`kernel528/alpine`](https://github.com/kernel528/alpine-docker), and publishes `kernel528/redis` for [`docker-swarm`](https://github.com/kernel528/docker-swarm). Publish and verify the Alpine tag before a base refresh. Publish and smoke-test the immutable Redis release before updating `stacks/redis-stack.yml`; deploy the stack separately and preserve the previous tag for rollback.
 
 ## CI Tagging (Drone)
-- `8.6.4` branch: validation build only (no publish).
-- `8` branch PRs publish versioned tags such as `8`, `8.6.4`, and `8.6.4-3.24.1_1`.
-- `main` branch push: publishes `latest`.
-- Git tags: publish `${DRONE_TAG}`.
+- PRs targeting `8` publish configured tags such as `8`, `8.6.4`, and `8.6.4-3.24.1_1`.
+- This PR behavior is retained for current CI compatibility; release-looking PR tags are not release-eligible until the merged `main` commit receives a GitHub tag/release.
+- `main` branch pushes test the existing `latest` image; they do not publish it.
+- Git tags publish `${DRONE_TAG}` and `latest`.


### PR DESCRIPTION
## Summary
- document Alpine, docker-workspace, and docker-swarm relationships
- align release instructions with current Drone triggers
- classify PR-published tags as pre-release and ineligible for Swarm

Documentation only; no image behavior changes.